### PR TITLE
Correction in affected product list

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2024/CVE-2022-45868.md
+++ b/en/docs/security-announcements/cve-justifications/2024/CVE-2022-45868.md
@@ -16,7 +16,7 @@ The web-based admin console in H2 Database Engine before 2.2.220 can be started 
 
 ### REPORTED PRODUCTS
 
-- WSO2 API Manager : 4.3.0, 4.2.0, 4.1.0, 4.0.0, 3.2.0, 3.1.0, 3.0.0
+- WSO2 API Manager : 4.2.0, 4.1.0, 4.0.0, 3.2.0, 3.1.0, 3.0.0
 - WSO2 Open Banking AM : 2.0.0, 1.5.0, 1.4.0
 - Any other WSO2 products containing the H2 Database Engine before 2.2.220
 
@@ -26,7 +26,7 @@ The vulnerability is reported when starting the H2 web based console using the C
 
 Furthermore, the H2 web based console is disabled by default, and newer WSO2 product versions including APIM 4.2.0 onwards even removes `deployment.toml` configuration option to enable/disable the H2 web console.
 
-Furthermore, the CVE-2022-45868[^1] is a disputed vulnerability and the project states the following:
+In addition, the CVE-2022-45868[^1] is a disputed vulnerability and the project states the following:
 
 > This is not a vulnerability of H2 Console Passwords should never be passed on the command line and every qualified DBA or system administrator is expected to know that.
 


### PR DESCRIPTION
APIM 4.3.0 is not vulnerable to mentioned CVE since it is using the latest H2 version. Hence, APIM 4.3.0 has been removed from affected product list. 