### PR TITLE
update justification for CVE-2024-6763

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
+++ b/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
@@ -25,7 +25,7 @@ The HttpURI class does insufficient validation on the authority segment of a URI
 
 In Jetty HTTP version 12.0.12 and onwards, this vulnerability has been addressed. However, Jetty HTTP 12.0.x requires Java 17 to support this dependency[^2]. Meanwhile, above listed WSO2 product versions still support Java versions below 17. Due to these concerns, we are publishing this CVE justification with a detailed analysis of the CVE, outlining how associated risks are mitigated in WSO2 products and the actions WSO2 is taking in response.
 
-As part of our analysis, we conducted a comprehensive review of the usage of Jetty’s HttpURI class across the affected WSO2 products. This included static code analysis and runtime dependency tracing. Our investigation confirmed that the HttpURI class, which is the specific component that could be exploited through this vulnerability, is neither referenced nor invoked anywhere in the relevant product codebases.
+As part of our analysis, we conducted a comprehensive review of the usage of Jetty’s HttpURI class across the aforementioned WSO2 products. This included static code analysis and runtime dependency tracing. Our investigation confirmed that the HttpURI class, which is the specific component that could be exploited through this vulnerability, is neither referenced nor invoked anywhere in the relevant product codebases.
 
 Based on this evidence, we conclude that this vulnerability does not pose a security risk to the impacted versions of WSO2 products listed above.
 


### PR DESCRIPTION
## Purpose
Update the CVE-2024-6763 justification to provide a more generalized explanation that covers all affected WSO2 products