### PR TITLE
Add H1 security bulletin of 2025 for Choreo

### DIFF
--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1.md
@@ -1,0 +1,32 @@
+
+---
+| Title | Category | Published | Version |
+|--------------|-------|----------|---------|
+|Choreo Security Bulletin – H1 2025|security-announcements|2025-07-15|1.0.0
+---
+
+# Choreo Security Bulletin – H1 2025
+
+<p class="doc-info">Published: 2025-07-15</p>
+<p class="doc-info">Version: 1.0.0</p>
+
+### BULLETIN ID  
+CHO-SB-2025-H1
+
+### SCOPE  
+This bulletin summarizes security vulnerabilities addressed during the H1 of 2025 for Choreo.
+
+### VULNERABILITIES ADDRESSED
+
+| Reference ID | Title | Severity | Summary |
+|--------------|-------|----------|---------|
+| CHO-2025-001 | Insecure Trust of id_token in Token Exchange Flow Leading to Potential Account Takeover in Choreo | Medium | Choreo STS trusts the id_token during token exchange to issue access tokens. Since id_tokens can be exposed via OIDC logout flows, this can lead to account takeover if an attacker obtains a valid id_token. |
+| CHO-2025-002 | Email Exposure in Access Logs via Query Parameter in User Invitation Delete API | Medium | User email is getting logged in access logs due to email is passed as a query parameter in the user invitation delete API. |
+| CHO-2025-003 | Tokens from Removed Key Manager Application Still Authorized in Choreo | Critical | JWT tokens issued by a previously configured Key Manager application in Asgardeo remain valid even after the application is removed from a Choreo service. This allows continued access to APIs using old tokens, which poses a security risk and contradicts expected token invalidation behavior upon Key Manager changes. |
+| CHO-2025-004 | Unauthorized Git Credential Creation by Low-Privileged User | Medium | Low-privileged users can add Git credentials to the organization, which should not be permitted by design. Although this does not directly affect the security posture (as Viewers cannot build or deploy), it violates the principle of least privilege and could allow setup of misleading or unverified Git sources. |
+| CHO-2025-005 | Git Credential Modification Causing Build Disruption | Medium | Low-privileged users are able to update existing Git credentials. While the modification doesn’t affect already running services, it can cause build failures if those credentials are used in a component rebuild, disrupting availability. This is a CI/CD pipeline risk that stems from improper privilege enforcement and could result in temporary denial of service for updates. |
+| CHO-2025-006 | NGINX “IngressNightmare” | Critical | Vulnerabilities in ingress configuration leading to potential unauthorized access or routing bypass. CVE-2025-1974, CVE-2025-24514, CVE-2025-1097, CVE-2025-1098, CVE-2025-24513 |
+
+### CREDITS  
+Choreo product team would like to thank all internal and external researchers for responsibly disclosing the above issues.
+

--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
@@ -1,9 +1,9 @@
 ---
-title: Choreo Security Bulletins
+title: Choreo Security Bulletins for 2025
 category: security-announcements
 ---
 
-# Cloud Security Bulletins
+# Choreo Security Bulletins for 2025
 
 This section contains the security bulletins for Choreo
 

--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
@@ -5,6 +5,6 @@ category: security-announcements
 
 # Choreo Security Bulletins for 2025
 
-This section contains the security bulletins for Choreo
+This section contains the Choreo security bulletins for 2025
 
 * [2025 H1]({{#base_path#}}/security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1)

--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
@@ -7,4 +7,4 @@ category: security-announcements
 
 This section contains the security bulletins for Choreo
 
-* [2025 Choreo Security Bulletins]({{#base_path#}}/security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1)
+* [2025 H1]({{#base_path#}}/security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1)

--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/2025/index.md
@@ -1,0 +1,10 @@
+---
+title: Choreo Security Bulletins
+category: security-announcements
+---
+
+# Cloud Security Bulletins
+
+This section contains the security bulletins for Choreo
+
+* [2025 Choreo Security Bulletins]({{#base_path#}}/security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1)

--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/index.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/index.md
@@ -7,4 +7,4 @@ category: security-announcements
 
 This section contains the security bulletins for Choreo
 
-* [2025 Security Bulletins]({{#base_path#}}/security-announcements//cloud-security-bulletins/choreo/2025/)
+* [2025 Choreo Security Bulletins]({{#base_path#}}/security-announcements/cloud-security-bulletins/choreo/2025/)

--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/index.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/index.md
@@ -7,4 +7,4 @@ category: security-announcements
 
 This section contains the security bulletins for Choreo
 
-* [2025 Choreo Security Bulletins]({{#base_path#}}/security-announcements/cloud-security-bulletins/choreo/2025/)
+* [2025]({{#base_path#}}/security-announcements/cloud-security-bulletins/choreo/2025/)

--- a/en/docs/security-announcements/cloud-security-bulletins/choreo/index.md
+++ b/en/docs/security-announcements/cloud-security-bulletins/choreo/index.md
@@ -3,7 +3,7 @@ title: Choreo Cloud Security Bulletins
 category: security-announcements
 ---
 
-# Cloud Security Bulletins
+# Choreo Cloud Security Bulletins
 
 This section contains the security bulletins for Choreo
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -359,7 +359,7 @@ nav:
         - '': 'security-announcements/cloud-security-bulletins/choreo/index.md'
         - '2025':
           - '': 'security-announcements/cloud-security-bulletins/choreo/2025/index.md'
-          - 'Choreo Security Bulletin - 2025 H1': 'security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1.md'        
+          - '2025 H1': 'security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1.md'        
     - 'CVE to WSO2 Security Advisory Mapping': 'security-announcements/cve-to-wso2-security-advisory-mapping.md'
     - 'CVE Justifications':
       - '': 'security-announcements/cve-justifications/index.md'

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -355,6 +355,11 @@ nav:
         - '2025':
           - '': 'security-announcements/cloud-security-bulletins/asgardeo/2025/index.md'
           - 'Asgardeo Security Bulletin - 2025 H1': 'security-announcements/cloud-security-bulletins/asgardeo/2025/asgardeo-2025-h1.md'
+      - 'Choreo':
+        - '': 'security-announcements/cloud-security-bulletins/choreo/index.md'
+        - '2025':
+          - '': 'security-announcements/cloud-security-bulletins/choreo/2025/index.md'
+          - 'Choreo Security Bulletin - 2025 H1': 'security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1.md'        
     - 'CVE to WSO2 Security Advisory Mapping': 'security-announcements/cve-to-wso2-security-advisory-mapping.md'
     - 'CVE Justifications':
       - '': 'security-announcements/cve-justifications/index.md'

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -354,7 +354,7 @@ nav:
         - '': 'security-announcements/cloud-security-bulletins/asgardeo/index.md'
         - '2025':
           - '': 'security-announcements/cloud-security-bulletins/asgardeo/2025/index.md'
-          - 'Asgardeo Security Bulletin - 2025 H1': 'security-announcements/cloud-security-bulletins/asgardeo/2025/asgardeo-2025-h1.md'
+          - '2025 H1': 'security-announcements/cloud-security-bulletins/asgardeo/2025/asgardeo-2025-h1.md'
       - 'Choreo':
         - '': 'security-announcements/cloud-security-bulletins/choreo/index.md'
         - '2025':


### PR DESCRIPTION
## Purpose
Provide a single, authoritative bulletin that aggregates all security vulnerabilities fixed in Choreo during January 2025.
Helps customers quickly assess exposure, plan upgrades, and satisfy audit / compliance needs.

## Goals
Publish “Choreo Security Bulletin – H1 2025” in the security-announcements section of docs.wso2.com.

## Approach
Added a new Markdown file (choreo-2025-h1.md) following the advisory front-matter schema.

## User stories
Security engineer wants a consolidated list of all Asgardeo fixes to update internal risk register.
Compliance officer needs an official doc to show auditors that critical CVEs have been addressed.

## Release note
Added Choreo Security Bulletin – H1 2025, summarizing all vulnerabilities fixed in in first half of 2025

## Documentation
This PR is the documentation. No further doc impact. (N/A)

## Training
N/A – bulletin does not alter product functionality.

## Certification
N/A – documentation-only change; no exam objectives affected.

## Marketing
N/A – handled by Security & PR teams via existing advisory channels.

## Automation tests
 - Unit tests 
  NA
 - Integration tests
  NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
macOS 13.4
 
## Learning
Reviewed historic WSO2 advisories for style; followed internal “Security Bulletin Authoring” SOP v2.3.