### PR TITLE
Remove CVE-to-WSO2 advisory mapping page and link CVEs directly to advisory

### DIFF
--- a/en/docs/security-announcements/index.md
+++ b/en/docs/security-announcements/index.md
@@ -9,6 +9,5 @@ This section contains the WSO2 Security Announcements, which belong to the follo
 
 * [WSO2 Security Advisories]({{#base_path#}}/security-announcements/security-advisories/): List of WSO2 Security Advisories that we have released in each year for WSO2 products. 
 * [Cloud Security Bulletins]({{#base_path#}}/security-announcements/cloud-security-bulletins/): List of the Security Bulletins that we have released in each year for WSO2 cloud offerings.
-* [CVE to WSO2 Security Advisory Mapping]({{#base_path#}}/security-announcements/cve-to-wso2-security-advisory-mapping/): There are CVEs assigned to some WSO2 Security Advisories. This contains the mapping table for WSO2 Security Advisories to each CVE.
 * [CVE Justifications]({{#base_path#}}/security-announcements/cve-justifications/): Contains clarifications and justifications for the CVEs that are associated with WSO2 products and do not require fixes.
 * [Incident Clarifications]({{#base_path#}}/security-announcements/incident-clarifications/): Contains clarifications regarding security Incidents which may have relevance to WSO2 and WSO2 customers.

--- a/en/docs/security-announcements/security-advisories/2017/WSO2-2017-0257.md
+++ b/en/docs/security-announcements/security-advisories/2017/WSO2-2017-0257.md
@@ -11,6 +11,7 @@ cvss: "6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: September 04, 2017</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2017-14995">CVE-2017-14995</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2017/WSO2-2017-0265.md
+++ b/en/docs/security-announcements/security-advisories/2017/WSO2-2017-0265.md
@@ -11,6 +11,7 @@ cvss: "5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:L/A:N)"
 <p class="doc-info">Published: September 04, 2017</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2017-14651">CVE-2017-14651</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0501.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0501.md
@@ -11,6 +11,7 @@ cvss: "3.5 (CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:N)"
 <p class="doc-info">Published: January 29, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 3.5 (CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2018-20736">CVE-2018-20736</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0504.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0504.md
@@ -11,6 +11,7 @@ cvss: "3.5 (CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:N)"
 <p class="doc-info">Published: January 29, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 3.5 (CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2018-20737">CVE-2018-20737</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0597.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0597.md
@@ -11,6 +11,7 @@ cvss: "3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Published: July 15, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-15108">CVE-2019-15108</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0616.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0616.md
@@ -11,6 +11,7 @@ cvss: "4.8 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: October 07, 2019</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.8 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20434">CVE-2019-20434</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0625.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0625.md
@@ -11,6 +11,7 @@ cvss: "6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: November 04, 2019</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-18881">CVE-2019-18881</a>, <a href="https://www.cve.org/CVERecord?id=CVE-2019-18882">CVE-2019-18882</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0633.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0633.md
@@ -11,6 +11,7 @@ cvss: "3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Published: October 07, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20435">CVE-2019-20435</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0634.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0634.md
@@ -11,6 +11,7 @@ cvss: "6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: October 07, 2019</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20436">CVE-2019-20436</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0635.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0635.md
@@ -11,6 +11,7 @@ cvss: "6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: October 07, 2019</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20437">CVE-2019-20437</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0636.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0636.md
@@ -11,6 +11,7 @@ cvss: "3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Published: December 02, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20442">CVE-2019-20442</a>, <a href="https://www.cve.org/CVERecord?id=CVE-2019-20443">CVE-2019-20443</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0644.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0644.md
@@ -11,6 +11,7 @@ cvss: "3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Published: November 04, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20439">CVE-2019-20439</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0645.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0645.md
@@ -11,6 +11,7 @@ cvss: "4.8 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: November 04, 2019</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.8 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20438">CVE-2019-20438</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0646.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0646.md
@@ -11,6 +11,7 @@ cvss: "3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Published: December 02, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 3.5 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20440">CVE-2019-20440</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0647.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0647.md
@@ -11,6 +11,7 @@ cvss: "4.8 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: November 04, 2019</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 4.8 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-20441">CVE-2019-20441</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0658.md
+++ b/en/docs/security-announcements/security-advisories/2019/WSO2-2019-0658.md
@@ -11,6 +11,7 @@ cvss: "6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Published: December 02, 2019</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2019-19587">CVE-2019-19587</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2019-0665.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2019-0665.md
@@ -11,6 +11,7 @@ cvss: "8.7 (CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:H)"
 <p class="doc-info">Published: May 07, 2020</p>
 <p class="doc-info">Severity: High</p>
 <p class="doc-info">CVSS Score: 8.7 (CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-12719">CVE-2020-12719</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0684.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0684.md
@@ -13,6 +13,7 @@ cvss: "4.0 (CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:C/C:L/I:N/A:L)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.0 (CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:C/C:L/I:N/A:L)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-11885">CVE-2020-11885</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0685.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0685.md
@@ -13,6 +13,7 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-24704">CVE-2020-24704</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0687.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0687.md
@@ -13,6 +13,7 @@ cvss: "8.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: High</p>
 <p class="doc-info">CVSS Score: 8.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-24703">CVE-2020-24703</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0707.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0707.md
@@ -13,6 +13,7 @@ cvss: "5.4 (CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.4 (CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-14444">CVE-2020-14444</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0711.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0711.md
@@ -13,6 +13,7 @@ cvss: "4.4 (CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.4 (CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-14445">CVE-2020-14445</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0713.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0713.md
@@ -13,6 +13,7 @@ cvss: "6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-14446">CVE-2020-14446</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0718.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0718.md
@@ -13,6 +13,7 @@ cvss: "XSS: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N), Session Hijackin
 <p class="doc-info">Version: 2.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: XSS: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N), Session Hijacking: 8.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-24705">CVE-2020-24705</a>, <a href="https://www.cve.org/CVERecord?id=CVE-2020-24706">CVE-2020-24706</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0727.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0727.md
@@ -13,6 +13,7 @@ cvss: "5.5 (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:H)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.5 (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-13883">CVE-2020-13883</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0728.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0728.md
@@ -13,6 +13,7 @@ cvss: "6.5 (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:H)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.5 (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-24591">CVE-2020-24591</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0742.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0742.md
@@ -13,6 +13,7 @@ cvss: "9.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Critical</p>
 <p class="doc-info">CVSS Score: 9.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-24589">CVE-2020-24589</a>, <a href="https://www.cve.org/CVERecord?id=CVE-2020-24590">CVE-2020-24590</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0781.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0781.md
@@ -13,6 +13,7 @@ cvss: "5.4 (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.4 (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-25516">CVE-2020-25516</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0843.md
+++ b/en/docs/security-announcements/security-advisories/2020/WSO2-2020-0843.md
@@ -13,6 +13,7 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-17454">CVE-2020-17454</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2021/WSO2-2020-1132.md
+++ b/en/docs/security-announcements/security-advisories/2021/WSO2-2020-1132.md
@@ -13,6 +13,7 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-17453">CVE-2020-17453</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2021/WSO2-2020-1233.md
+++ b/en/docs/security-announcements/security-advisories/2021/WSO2-2020-1233.md
@@ -13,6 +13,7 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2020-27885">CVE-2020-27885</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2021/WSO2-2021-1289.md
+++ b/en/docs/security-announcements/security-advisories/2021/WSO2-2021-1289.md
@@ -13,6 +13,7 @@ cvss: "5.2 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:L)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.2 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:L)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2021-42646">CVE-2021-42646</a></p>
 ---
 
 !!! info

--- a/en/docs/security-announcements/security-advisories/2022/WSO2-2021-1603.md
+++ b/en/docs/security-announcements/security-advisories/2022/WSO2-2021-1603.md
@@ -13,6 +13,7 @@ cvss: "4.6 (CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.6 (CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2022-29548">CVE-2022-29548</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2022/WSO2-2021-1738.md
+++ b/en/docs/security-announcements/security-advisories/2022/WSO2-2021-1738.md
@@ -16,6 +16,7 @@ cve-id: CVE-2022-29464
 <p class="doc-info">Version: 1.3.0</p>
 <p class="doc-info">Severity: Critical</p>
 <p class="doc-info">CVSS Score: 9.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2022-29464">CVE-2022-29464</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2022/WSO2-2022-1698.md
+++ b/en/docs/security-announcements/security-advisories/2022/WSO2-2022-1698.md
@@ -13,6 +13,7 @@ cvss: "5.4 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.4 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2022-39809">CVE-2022-39809</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2023-2987.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2023-2987.md
@@ -13,6 +13,7 @@ cvss: "5.4 CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.4 CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-0392">CVE-2024-0392</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-2701.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-2701.md
@@ -13,6 +13,8 @@ cvss: "4.3 (CVSS:3.1/AV:A/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.3 (CVSS:3.1/AV:A/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-3509">CVE-2024-3509</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3171.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3171.md
@@ -13,6 +13,8 @@ cvss: "5.4 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.4 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-1440">CVE-2024-1440</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3213.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3213.md
@@ -13,6 +13,8 @@ cvss: "5.6 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.6 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-2321">CVE-2024-2321</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3348.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3348.md
@@ -13,6 +13,8 @@ cvss: "5.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-3348">CVE-2024-3348</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3425.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3425.md
@@ -13,6 +13,8 @@ cvss: "4.6 (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.6 (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-7103">CVE-2024-7103</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3443.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3443.md
@@ -13,6 +13,8 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-5962">CVE-2024-5962</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3450.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3450.md
@@ -13,6 +13,8 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-5848">CVE-2024-5848</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3561.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3561.md
@@ -9,6 +9,7 @@ version: 1.0.0
 
 <p class="doc-info">Published: November 10, 2024</p>
 <p class="doc-info">Version: 1.0.0</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-6914">CVE-2024-6914</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3562.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3562.md
@@ -13,6 +13,7 @@ cvss: "6.5 (CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.5 (CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-7073">CVE-2024-7073</a></p>
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3566.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3566.md
@@ -13,6 +13,8 @@ cvss: "6.8 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.8 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-7074">CVE-2024-7074</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3573.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3573.md
@@ -13,6 +13,8 @@ cvss: "4.2 (CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.2 (CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-7096">CVE-2024-7096</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3574.md
+++ b/en/docs/security-announcements/security-advisories/2024/WSO2-2024-3574.md
@@ -13,6 +13,8 @@ cvss: "4.3 (CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.3 (CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-7097">CVE-2024-7097</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2023-3084.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2023-3084.md
@@ -14,6 +14,8 @@ cvss: "6.4 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:L/I:H/A:H)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.4 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:L/I:H/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-4457">CVE-2024-4457</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2023-3098.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2023-3098.md
@@ -14,6 +14,8 @@ cvss: "2.7 (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Low</p>
 <p class="doc-info">CVSS Score: 2.7 (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-4412">CVE-2024-4412</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-2702.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-2702.md
@@ -14,6 +14,8 @@ cvss: "4.3 (CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.3 (CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-3511">CVE-2024-3511</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3144.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3144.md
@@ -14,6 +14,8 @@ cvss: "7.7 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: High</p>
 <p class="doc-info">CVSS Score: 7.7 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-1524">CVE-2024-1524</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3149.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3149.md
@@ -13,6 +13,8 @@ cvss: "5.9 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.9 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-8122">CVE-2024-8122</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3178.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3178.md
@@ -14,6 +14,8 @@ cvss: "5.2 (CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.2 (CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-8008">CVE-2024-8008</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3217.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3217.md
@@ -14,6 +14,8 @@ cvss: "4.8 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.8 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-2323">CVE-2024-2323</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3382.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3382.md
@@ -14,6 +14,8 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-5139">CVE-2024-5139</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3403.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3403.md
@@ -14,6 +14,8 @@ cvss: "5.4 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.4 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-4989">CVE-2024-4989</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3414.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3414.md
@@ -14,6 +14,8 @@ cvss: "4.8 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.8 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-5617">CVE-2024-5617</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3436.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3436.md
@@ -14,6 +14,8 @@ cvss: "4.8 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.8 (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-5563">CVE-2024-5563</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3490.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3490.md
@@ -13,6 +13,8 @@ cvss: "4.3 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 4.3 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-6429">CVE-2024-6429</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3606.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2024-3606.md
@@ -14,6 +14,8 @@ cvss: "5.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 5.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2024-7478">CVE-2024-7478</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3857.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3857.md
@@ -14,6 +14,8 @@ cvss: "6.3 (CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.3 (CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2025-0326">CVE-2025-0326</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3864.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3864.md
@@ -13,6 +13,8 @@ cvss: "6.8 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.8 (CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2025-0663">CVE-2025-0663</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3902.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3902.md
@@ -13,6 +13,8 @@ cvss: "6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Medium</p>
 <p class="doc-info">CVSS Score: 6.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2025-0209">CVE-2025-0209</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3993.md
+++ b/en/docs/security-announcements/security-advisories/2025/WSO2-2025-3993.md
@@ -13,6 +13,8 @@ cvss: "6.3 (CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N)"
 <p class="doc-info">Version: 1.0.0</p>
 <p class="doc-info">Severity: Critical</p>
 <p class="doc-info">CVSS Score: 9.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H)</p>
+<p class="doc-info">CVE IDs: <a href="https://www.cve.org/CVERecord?id=CVE-2025-2905">CVE-2025-2905</a></p>
+
 ---
 
 ### AFFECTED PRODUCTS

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -360,7 +360,6 @@ nav:
         - '2025':
           - '': 'security-announcements/cloud-security-bulletins/choreo/2025/index.md'
           - '2025 H1': 'security-announcements/cloud-security-bulletins/choreo/2025/choreo-2025-h1.md'        
-    - 'CVE to WSO2 Security Advisory Mapping': 'security-announcements/cve-to-wso2-security-advisory-mapping.md'
     - 'CVE Justifications':
       - '': 'security-announcements/cve-justifications/index.md'
       - '2025':


### PR DESCRIPTION
### Summary
This PR removes the CVE-to-WSO2 advisory mapping page, which was previously used to map CVEs to advisories indirectly.

### Changes
- Deleted the links to the dedicated CVE mapping page
- Updated relevant pages to link CVEs directly to their corresponding WSO2 advisories
- Ensured all existing references are updated to the new linking approach

### Reason
The mapping page was redundant and created an extra step for users. Directly linking CVEs to advisories improves usability, reduces maintenance overhead, and ensures users can access the correct advisory without additional navigation.

### Impact
- Simplifies CVE-to-advisory navigation
- Removes an unused/duplicate page
- No breaking changes to other sections

### Testing
- Verified all CVE links point to the correct advisory pages
- Checked for broken links after page removal
