### PR TITLE
Updated the acknowledgement entries for March 2026

### DIFF
--- a/en/docs/security-reporting/reward-and-acknowledgement-program/hall-of-fame.md
+++ b/en/docs/security-reporting/reward-and-acknowledgement-program/hall-of-fame.md
@@ -21,8 +21,12 @@ security researcher community relationship.
 | :------------------------------------------------------------------------------------------------------------------- |
 | [Alex Williams from Pellera Technologies](https://www.linkedin.com/in/alexanderwilliamscyber)                        |
 | [Claire Wang](https://clairewang.net/)                                                                               |
+| [Lasantha Karunarathne](https://www.linkedin.com/in/lasakaru/)                                                       |
 | [Manisha Dilshan](https://www.linkedin.com/in/manisha-dilshan-b08ba3215)                                             |
 | [Michał Majchrowicz, Marcin Wyczechowski, and Paweł Zdunek — members of the AFINE Team](https://afine.com/)          |
+| **Omri Inbar**                                                                                                       |
+| [Robert C. Raducioiu](https://it.linkedin.com/in/rbct)                                                               |
+
 
 
 ### Asgardeo
@@ -32,6 +36,14 @@ security researcher community relationship.
 | [Hamed Elnwasani from DeepStrike](https://deepstrike.io/)           |
 | [Mahmoud Osama](https://www.linkedin.com/in/mahmoud0x00/)           |
 
+
+
+### Choreo
+
+|                                                                                                                      |
+| :------------------------------------------------------------------------------------------------------------------- |
+| [AGS Lakpahana](https://www.linkedin.com/in/lakpahana)                                                               |
+| [Alex Roger from Laburity](https://laburity.com)                                                               |
 
 ## 2025
 


### PR DESCRIPTION
## Purpose
> Hall of fame entries for the march

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hall of Fame with 2026 acknowledgements recognizing WSO2 Products and Infrastructure contributors.
  * Added new Choreo subsection to Hall of Fame, expanding recognition of additional 2026 contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->