### PR TITLE
Add CVE justification for GHSA-72hv-8253-57qq

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2026/GHSA-72hv-8253-57qq.md
+++ b/en/docs/security-announcements/cve-justifications/2026/GHSA-72hv-8253-57qq.md
@@ -1,0 +1,28 @@
+---
+title: "GHSA-72hv-8253-57qq"
+category: security-announcements
+---
+
+# GHSA-72hv-8253-57qq
+
+<p class="doc-info">WSO2 Products impacted: no</p>
+<p class="doc-info">Customer actions required: no</p>
+---
+
+### REPORTED VULNERABILITY
+A Denial of Service (DoS) vulnerability (CWE-770, Medium severity) exists in Jackson Core versions 2.0.0 through 2.18.5. A crafted numeric value can bypass the number length constraint in jackson-core's async (non-blocking) JSON parser (NonBlockingJsonParser), leading to excessive memory consumption [^1].
+
+### REPORTED PRODUCTS
+* WSO2 Identity Server : 7.3.0
+
+### WSO2 JUSTIFICATION
+The flagged Jackson Core library is not used directly by WSO2 Identity Server. It is embedded within the Hazelcast clustering library as an internal dependency. The vulnerability specifically affects the async (non-blocking) JSON parser in jackson-core, which is never used by Hazelcast. Hazelcast's own security team has confirmed that this vulnerability is not exploitable in their product [^2]. In WSO2 Identity Server, Hazelcast is used solely for clustering and caching, and no untrusted user input reaches its internal JSON parsing. Therefore, the vulnerable code path is unreachable and does not pose a security risk.
+
+A remediated Jackson Core is available from Hazelcast 5.6.0 onwards. However, upgrading from the currently shipped Hazelcast 5.3.6 to 5.6.0 spans multiple minor versions, each version introducing breaking API and behavioral changes [^3][^4][^5]. Due to these concerns, we are publishing this CVE justification with a detailed analysis outlining how the associated risk is mitigated in WSO2 Identity Server.
+
+### REFERENCES
+[^1]: [https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq](https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq)
+[^2]: [https://github.com/hazelcast/hazelcast/issues/26578#issuecomment-4125517789](https://github.com/hazelcast/hazelcast/issues/26578#issuecomment-4125517789)
+[^3]: [https://docs.hazelcast.com/hazelcast/5.6/release-notes/community#breaking-changes](https://docs.hazelcast.com/hazelcast/5.6/release-notes/community#breaking-changes)
+[^4]: [https://docs.hazelcast.com/hazelcast/5.5/release-notes/community#breaking-changes](https://docs.hazelcast.com/hazelcast/5.5/release-notes/community#breaking-changes)
+[^5]: [https://docs.hazelcast.com/hazelcast/5.4/release-notes/community#breaking-changes](https://docs.hazelcast.com/hazelcast/5.4/release-notes/community#breaking-changes)

--- a/en/docs/security-announcements/cve-justifications/2026/index.md
+++ b/en/docs/security-announcements/cve-justifications/2026/index.md
@@ -5,6 +5,7 @@ category: security-announcements
 
 # 2026 CVE Justifications
 
+- [GHSA-72hv-8253-57qq]({{#base_path#}}/security-announcements/cve-justifications/2026/GHSA-72hv-8253-57qq)
 - [CVE-2020-11023]({{#base_path#}}/security-announcements/cve-justifications/2026/CVE-2020-11023)
 - [CVE-2020-11022]({{#base_path#}}/security-announcements/cve-justifications/2026/CVE-2020-11022)
 - [CVE-2020-7656]({{#base_path#}}/security-announcements/cve-justifications/2026/CVE-2020-7656)

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -424,6 +424,7 @@ nav:
       - '': 'security-announcements/cve-justifications/index.md'
       - '2026':
         - '': 'security-announcements/cve-justifications/2026/index.md'
+        - 'GHSA-72hv-8253-57qq': 'security-announcements/cve-justifications/2026/GHSA-72hv-8253-57qq.md'
         - 'CVE-2020-11023': 'security-announcements/cve-justifications/2026/CVE-2020-11023.md'
         - 'CVE-2020-11022': 'security-announcements/cve-justifications/2026/CVE-2020-11022.md'
         - 'CVE-2020-7656': 'security-announcements/cve-justifications/2026/CVE-2020-7656.md'


### PR DESCRIPTION
## Purpose
Document why GHSA-72hv-8253-57qq (Jackson Core DoS vulnerability) does not affect WSO2 Identity Server 7.3.0. The vulnerable async JSON parser in jackson-core is embedded within the Hazelcast clustering library but is never invoked by Hazelcast or WSO2 IS, making the code path unreachable.
<img width="1920" height="1080" alt="Screenshot 2026-04-08 at 8 59 42 AM (2)" src="https://github.com/user-attachments/assets/463c3ba0-f3c2-4961-b74b-9ed28c3b3d39" />
<img width="1920" height="1080" alt="Screenshot 2026-04-08 at 8 59 45 AM (2)" src="https://github.com/user-attachments/assets/eea4f675-970c-43bf-a9df-1782a7a1062d" />

## Related Issue
Fixes wso2/docs-security#196

## Implementation
- Added `GHSA-72hv-8253-57qq.md` with a full justification explaining the non-exploitability, referencing Hazelcast's own confirmation and the breaking-change rationale for not upgrading Hazelcast.
- Updated `en/docs/security-announcements/cve-justifications/2026/index.md` to include the new entry.
- Updated `en/mkdocs.yml` navigation to register the new page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security vulnerability documentation for Jackson Core DoS vulnerability (GHSA-72hv-8253-57qq) including impact assessment and justification information for WSO2 Identity Server 7.3.0.
  * Updated CVE Justifications index and navigation to include new security documentation entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->