### PR TITLE
Update CVE-2025-11143 justification to include WSO2 Identity Server versions

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2026/CVE-2025-11143.md
+++ b/en/docs/security-announcements/cve-justifications/2026/CVE-2025-11143.md
@@ -17,10 +17,11 @@ The Jetty URI parser performs inconsistent parsing of malformed or unusual URIs 
 ### REPORTED PRODUCTS
 
 - WSO2 API Manager : 3.0.0, 3.1.0, 3.2.0, 3.2.1, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.7.0
+- WSO2 Identity Server : 5.11.0, 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0
 
 ### WSO2 JUSTIFICATION
 
-This vulnerability has been addressed in Jetty HTTP version 12.0.31 and above in the 12.0.x series, and version 12.1.5 and above in the 12.1.x series. However Jetty HTTP is an embedded dependency in Solr. Migrating to the non vulnerable Solr 10.x versions includes breaking changes in the context of WSO2 API Manager. Due to this reason, we are publishing this CVE justification with a detailed analysis of the CVE, outlining how associated risks are mitigated in WSO2 products and the actions WSO2 is taking in response.
+This vulnerability has been addressed in Jetty HTTP version 12.0.31 and above in the 12.0.x series, and version 12.1.5 and above in the 12.1.x series. However, Jetty HTTP is an embedded dependency in Solr, and addressing this vulnerability requires migrating to non-vulnerable Solr 10.x versions. Migrating to non-vulnerable Solr 10.x versions introduces breaking changes in the context of WSO2 API Manager. Additionally, the listed WSO2 Identity Server versions and WSO2 API Manager versions below 4.7.0 support Java versions earlier than 21, while Solr 10.x requires Java 21 or higher, making the upgrade path incompatible. Due to these reasons, we are publishing this CVE justification with a detailed analysis of the CVE, outlining how associated risks are mitigated in WSO2 products and the actions WSO2 is taking in response.
 
 The vulnerable `jetty-http` dependency is included transitively through the Apache Solr bundle, which supports content and artifact search capabilities in the product portals of the affected WSO2 product versions.
 


### PR DESCRIPTION
## Purpose
> $Subject