### PR TITLE
Add APIM 3.2.1 for CVE-2024-6763 justification

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
+++ b/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
@@ -17,7 +17,7 @@ The HttpURI class does insufficient validation on the authority segment of a URI
 ### REPORTED PRODUCTS
 
 - WSO2 Identity Server : 5.10.0, 5.11.0, 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0
-- WSO2 API Manager : 3.0.0, 3.1.0, 3.2.0, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0
+- WSO2 API Manager : 3.0.0, 3.1.0, 3.2.0, 3.2.1, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0
 - WSO2 MI Dashboard : 1.2.0, 4.1.0, 4.2.0
 - WSO2 Integration Control Plane : 1.0.0
 


### PR DESCRIPTION
### Purpose

Add an update to the list of affected versions for WSO2 API Manager in the CVE justification document. The change adds version 3.2.1 to the list of reported products impacted by the vulnerability.

- Documentation update:
  * Added `3.2.1` to the list of affected WSO2 API Manager versions in `CVE-2024-6763.md`.