### PR TITLE
Add APIM 3.2.1 for the CVE-2017-15708 justification

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2025/CVE-2017-15708.md
+++ b/en/docs/security-announcements/cve-justifications/2025/CVE-2017-15708.md
@@ -14,7 +14,7 @@ date: Feb 25 2025
 In Apache Synapse, by default no authentication is required for Java Remote Method Invocation (RMI). So Apache Synapse 3.0.1 or all previous releases (3.0.0, 2.1.0, 2.0.0, 1.2, 1.1.2, 1.1.1) allows remote code execution attacks that can be performed by injecting specially crafted serialized objects. And the presence of Apache Commons Collections 3.2.1 (commons-collections-3.2.1.jar) or previous versions in Synapse distribution makes this exploitable [^1].
 
 ### REPORTED PRODUCTS
-* WSO2 API Manager : 2.6.0, 3.0.0, 3.1.0, 3.2.0, 4.0.0, 4.1.0, 4.2.0
+* WSO2 API Manager : 2.6.0, 3.0.0, 3.1.0, 3.2.0, 3.2.1, 4.0.0, 4.1.0, 4.2.0
 * WSO2 Micro Integrator : 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0
 * WSO2 Enterprise Integrator : 6.6.0 
 


### PR DESCRIPTION
## Purpose
Add an update to the list of affected versions for WSO2 API Manager in the CVE justification document. The change adds version 3.2.1 to the list of reported products impacted by the vulnerability.

- Documentation update:
  - Added 3.2.1 to the list of affected WSO2 API Manager versions in CVE-2017-15708.md. 