### PR TITLE
Modify Justification and Add Missing APIM Products for CVE-2024-6763

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
+++ b/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
@@ -26,7 +26,7 @@ The HttpURI class does insufficient validation on the authority segment of a URI
 
 ### WSO2 JUSTIFICATION
 
-In Jetty HTTP version 12.0.12 and later, this vulnerability has been addressed. However, upgrading to Jetty HTTP 12.0.x is not a straightforward option for all affected WSO2 product versions, as certain product releases continue to support Java runtimes below the minimum version required by Jetty HTTP 12.0.x. Due to these concerns, we are publishing this CVE justification with a detailed analysis of the CVE, outlining how associated risks are mitigated in WSO2 products and the actions WSO2 is taking in response.
+In Jetty HTTP version 12.0.12 and later, this vulnerability has been addressed. However, upgrading to Jetty HTTP 12.0.x is not a straightforward option for all affected WSO2 product versions, as certain product releases continue to support Java runtimes below the minimum version required by Jetty HTTP 12.0.x [^2]. Due to these concerns, we are publishing this CVE justification with a detailed analysis of the CVE, outlining how associated risks are mitigated in WSO2 products and the actions WSO2 is taking in response.
 
 As part of our analysis, we conducted a comprehensive review of the usage of Jetty’s HttpURI class across the aforementioned WSO2 products. This included static code analysis and runtime dependency tracing. Our investigation confirmed that the HttpURI class, which is the specific component that could be exploited through this vulnerability, is neither referenced nor invoked anywhere in the relevant product codebases.
 

--- a/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
+++ b/en/docs/security-announcements/cve-justifications/2025/CVE-2024-6763.md
@@ -17,13 +17,16 @@ The HttpURI class does insufficient validation on the authority segment of a URI
 ### REPORTED PRODUCTS
 
 - WSO2 Identity Server : 5.10.0, 5.11.0, 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0
-- WSO2 API Manager : 3.0.0, 3.1.0, 3.2.0, 3.2.1, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0
+- WSO2 API Manager : 3.0.0, 3.1.0, 3.2.0, 3.2.1, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.7.0
+- WSO2 API Control Plane: 4.5.0, 4.6.0, 4.7.0
+- WSO2 Universal Gateway: 4.5.0, 4.6.0, 4.7.0
+- WSO2 Traffic Manager: 4.5.0, 4.6.0, 4.7.0
 - WSO2 MI Dashboard : 1.2.0, 4.1.0, 4.2.0
 - WSO2 Integration Control Plane : 1.0.0
 
 ### WSO2 JUSTIFICATION
 
-In Jetty HTTP version 12.0.12 and onwards, this vulnerability has been addressed. However, Jetty HTTP 12.0.x requires Java 17 to support this dependency[^2]. Meanwhile, above listed WSO2 product versions still support Java versions below 17. Due to these concerns, we are publishing this CVE justification with a detailed analysis of the CVE, outlining how associated risks are mitigated in WSO2 products and the actions WSO2 is taking in response.
+In Jetty HTTP version 12.0.12 and later, this vulnerability has been addressed. However, upgrading to Jetty HTTP 12.0.x is not a straightforward option for all affected WSO2 product versions, as certain product releases continue to support Java runtimes below the minimum version required by Jetty HTTP 12.0.x. Due to these concerns, we are publishing this CVE justification with a detailed analysis of the CVE, outlining how associated risks are mitigated in WSO2 products and the actions WSO2 is taking in response.
 
 As part of our analysis, we conducted a comprehensive review of the usage of Jetty’s HttpURI class across the aforementioned WSO2 products. This included static code analysis and runtime dependency tracing. Our investigation confirmed that the HttpURI class, which is the specific component that could be exploited through this vulnerability, is neither referenced nor invoked anywhere in the relevant product codebases.
 


### PR DESCRIPTION
## Purpose
- Modify justification content to remove the Java version constraint
- Add an update to the list of affected versions for WSO2 API Manager in the CVE justification document. The change adds missing APIM versions to the list of reported products impacted by the vulnerability