### PR TITLE
Add justification for CVE-2026-71497

### DIFF
--- a/en/docs/security-announcements/cve-justifications/2026/CVE-2026-71497.md
+++ b/en/docs/security-announcements/cve-justifications/2026/CVE-2026-71497.md
@@ -1,0 +1,29 @@
+---
+title: "CVE-2026-71497"
+category: security-announcements
+---
+
+# CVE-2026-71497
+
+<p class="doc-info">WSO2 Products impacted: no</p>
+<p class="doc-info">Customer actions required: no</p>
+---
+
+### REPORTED VULNERABILITY
+When a custom `Safelist` permits certain raw-text elements, jsoup may incorrectly sanitize malformed HTML containing a tag name that ends in a control character. The tag may acquire the parsing behavior of a different element, causing content that should remain text to be emitted as active markup after serialization, and potentially allowing cross-site scripting (XSS). jsoup's built-in Safelists are unaffected [^1].
+
+Affected versions: `>= 1.14.3, < 1.23.1`. Fixed in jsoup `1.23.1`.
+
+### REPORTED PRODUCTS
+* WSO2 Micro Integrator : 4.5.0, 4.6.0
+
+### WSO2 JUSTIFICATION
+`jsoup` is not shipped as a standalone dependency in WSO2 Micro Integrator. WSO2 Micro Integrator bundles jinjava version 2.7.6, which repackages jsoup version 1.15.3 as an internal dependency — a version within the affected range.
+
+A source-code review of jinjava 2.7.6 confirmed that jsoup's `Safelist` is referenced in exactly one location, `StripTagsFilter` [^2], where the code calls `Jsoup.clean(cleanedVal, Safelist.none())`. `Safelist.none()` is jsoup's own built-in Safelist.
+
+Since a custom Safelist permitting a raw-text element does not exist in WSO2 Micro Integrator, this vulnerability is not exploitable in this product.
+
+### REFERENCES
+[^1]: [https://github.com/advisories/GHSA-pmhh-3w7g-xqp8](https://github.com/advisories/GHSA-pmhh-3w7g-xqp8)
+[^2]: [https://github.com/HubSpot/jinjava/blob/jinjava-2.7.6/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java#L47](https://github.com/HubSpot/jinjava/blob/jinjava-2.7.6/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java#L47)

--- a/en/docs/security-announcements/cve-justifications/2026/CVE-2026-71497.md
+++ b/en/docs/security-announcements/cve-justifications/2026/CVE-2026-71497.md
@@ -16,6 +16,10 @@ Affected versions: `>= 1.14.3, < 1.23.1`. Fixed in jsoup `1.23.1`.
 
 ### REPORTED PRODUCTS
 * WSO2 Micro Integrator : 4.5.0, 4.6.0
+* WSO2 API Manager : 3.2.0, 3.2.1, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.7.0
+* WSO2 API Control Plane : 4.5.0, 4.6.0, 4.7.0
+* WSO2 Universal Gateway : 4.5.0, 4.6.0, 4.7.0
+* WSO2 Traffic Manager : 4.5.0, 4.6.0, 4.7.0
 
 ### WSO2 JUSTIFICATION
 `jsoup` is not shipped as a standalone dependency in WSO2 Micro Integrator. WSO2 Micro Integrator bundles jinjava version 2.7.6, which repackages jsoup version 1.15.3 as an internal dependency — a version within the affected range.

--- a/en/docs/security-announcements/cve-justifications/2026/index.md
+++ b/en/docs/security-announcements/cve-justifications/2026/index.md
@@ -5,6 +5,7 @@ category: security-announcements
 
 # 2026 CVE Justifications
 
+- [CVE-2026-71497]({{#base_path#}}/security-announcements/cve-justifications/2026/CVE-2026-71497)
 - [CVE-2026-41851]({{#base_path#}}/security-announcements/cve-justifications/2026/CVE-2026-41851)
 - [CVE-2026-41848]({{#base_path#}}/security-announcements/cve-justifications/2026/CVE-2026-41848)
 - [GHSA-72hv-8253-57qq]({{#base_path#}}/security-announcements/cve-justifications/2026/GHSA-72hv-8253-57qq)

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -476,6 +476,7 @@ nav:
       - '': 'security-announcements/cve-justifications/index.md'
       - '2026':
         - '': 'security-announcements/cve-justifications/2026/index.md'
+        - 'CVE-2026-71497': 'security-announcements/cve-justifications/2026/CVE-2026-71497.md'
         - 'CVE-2026-41851': 'security-announcements/cve-justifications/2026/CVE-2026-41851.md'
         - 'CVE-2026-41848': 'security-announcements/cve-justifications/2026/CVE-2026-41848.md'
         - 'GHSA-72hv-8253-57qq': 'security-announcements/cve-justifications/2026/GHSA-72hv-8253-57qq.md'


### PR DESCRIPTION
## Purpose
Adds a public justification for CVE-2026-71497 (jsoup: XSS via malformed tag names with a custom Safelist permitting raw-text elements).